### PR TITLE
Add note proposal feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/note-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/note-proposal.yml
@@ -1,0 +1,28 @@
+name: "Note Proposal"
+description: "Propose a new note to be added to hpmor.info"
+title: "[Note Proposal] "
+labels: ["note-proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill out the following form to propose a new note to be added to hpmor.info.
+        Please add a short title for the issue above (for internal use, this will not be included in the note). 
+  - type: input
+    id: paragraph_number
+    attributes:
+      label: "Paragraph Number"
+      description: "The paragraph number to which the note will be added. Paragraph numbers are shown on hpmor.info to the left of the text."
+      placeholder: "Enter the paragraph number, e.g. 150"
+  - type: input
+    id: author
+    attributes:
+      label: "Author"
+      description: "The author of the note. Can be left blank, or your name, or a link (URL) to your GitHub or reddit profile."
+      placeholder: "Enter the author's name"
+  - type: textarea
+    id: text
+    attributes:
+      label: "Text"
+      description: "The text of the note."
+      placeholder: "Enter the text of the note"

--- a/.github/workflow_scripts/add_note.py
+++ b/.github/workflow_scripts/add_note.py
@@ -1,0 +1,56 @@
+import sys
+from ruamel.yaml import YAML
+from datetime import datetime
+
+def parse_issue(issue_body):
+    lines = issue_body.split('\n')
+    paragraph_number = None
+    author = None
+    text = None
+    
+    current_section = None
+    text_lines = []
+    
+    for line in lines:
+        line = line.strip()
+        if line.startswith('### '):
+            current_section = line[4:]
+        elif line and current_section:
+            if current_section == 'Paragraph Number':
+                paragraph_number = int(line)
+            elif current_section == 'Author':
+                author = line
+            elif current_section == 'Text':
+                text_lines.append(line)
+    
+    text = '\n'.join(text_lines).strip()
+    return paragraph_number, author, text
+    
+
+def add_note_to_yaml(paragraph_number, author, text, issue_date, origin):
+    yaml = YAML()
+    for i in range(1, 123):
+        with open(f"yaml/{i}.yaml", "r") as f:
+            chapter = yaml.load(f)
+        if paragraph_number in chapter:
+            if 'notes' not in chapter[paragraph_number]:
+                chapter[paragraph_number]['notes'] = []
+            chapter[paragraph_number]['notes'].append({
+                'type': 'original',
+                'date': issue_date,
+                'author': author,
+                'origin': origin,
+                'text': text
+            })
+            with open(f"yaml/{i}.yaml", "w") as f:
+                yaml.dump(chapter, f)
+            break
+
+if __name__ == "__main__":
+    issue_body = sys.argv[1]
+    issue_date = datetime.strptime(sys.argv[2], "%Y-%m-%d").strftime("%Y/%m/%d")
+    paragraph_number, author, text = parse_issue(issue_body)
+    if author == "_No response_":
+        author = ""
+    origin = sys.argv[3]
+    add_note_to_yaml(paragraph_number, author, text, issue_date, origin)

--- a/.github/workflows/note-proposal.yml
+++ b/.github/workflows/note-proposal.yml
@@ -2,6 +2,8 @@ name: Process Note Proposals
 on:
   issues:
     types: [opened, edited]
+env:
+    GH_TOKEN: ${{ github.token }}
 jobs:
   process-note-proposal:
     if: contains(github.event.issue.labels.*.name, 'note-proposal')
@@ -9,13 +11,15 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
+        with:
+          ref: master
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip install pyyaml
+          pip install beautifulsoup4 tqdm ruamel.yaml
       - name: Parse issue and create branch
         id: parse_issue
         run: |
@@ -25,23 +29,26 @@ jobs:
           ISSUE_DATE=$(echo "${{ github.event.issue.created_at }}" | cut -d'T' -f1)
           echo "##[set-output name=branch_name;]${BRANCH_NAME}"
           echo "##[set-output name=issue_date;]${ISSUE_DATE}"
-          echo "Creating branch ${BRANCH_NAME}..."
-          git checkout -b ${BRANCH_NAME}
+          
+          # Create/reset feature branch from master
+          git checkout -B ${BRANCH_NAME}
       - name: Add note to YAML file
         run: |
           echo "Adding note to YAML file..."
-          python add_note.py "${{ github.event.issue.body }}" "${{ steps.parse_issue.outputs.branch_name }}" "${{ steps.parse_issue.outputs.issue_date }}"
-      - name: Commit changes
+          python .github/workflow_scripts/add_note.py "${{ github.event.issue.body }}" "${{ steps.parse_issue.outputs.issue_date }}" "${{ github.event.issue.url }}"
+      - name: Commit and push changes
         run: |
           echo "Committing changes..."
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Add note from issue #${{ github.event.issue.number }}"
-      - name: Push changes
-        run: |
-          echo "Pushing changes..."
-          git push --set-upstream origin ${{ steps.parse_issue.outputs.branch_name }}
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Add note from issue #${{ github.event.issue.number }}"
+            echo "Force pushing changes..."
+            git push -f origin ${{ steps.parse_issue.outputs.branch_name }}
+          fi
       - name: Comment on issue with PR link
         run: |
           ISSUE_NUMBER=$(echo "${{ github.event.issue.number }}")

--- a/.github/workflows/note-proposal.yml
+++ b/.github/workflows/note-proposal.yml
@@ -1,0 +1,51 @@
+name: Process Note Proposals
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  process-note-proposal:
+    if: contains(github.event.issue.labels.*.name, 'note-proposal')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install pyyaml
+      - name: Parse issue and create branch
+        id: parse_issue
+        run: |
+          echo "Parsing issue..."
+          ISSUE_NUMBER=$(echo "${{ github.event.issue.number }}")
+          BRANCH_NAME="note-proposal-${ISSUE_NUMBER}"
+          ISSUE_DATE=$(echo "${{ github.event.issue.created_at }}" | cut -d'T' -f1)
+          echo "##[set-output name=branch_name;]${BRANCH_NAME}"
+          echo "##[set-output name=issue_date;]${ISSUE_DATE}"
+          echo "Creating branch ${BRANCH_NAME}..."
+          git checkout -b ${BRANCH_NAME}
+      - name: Add note to YAML file
+        run: |
+          echo "Adding note to YAML file..."
+          python add_note.py "${{ github.event.issue.body }}" "${{ steps.parse_issue.outputs.branch_name }}" "${{ steps.parse_issue.outputs.issue_date }}"
+      - name: Commit changes
+        run: |
+          echo "Committing changes..."
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Add note from issue #${{ github.event.issue.number }}"
+      - name: Push changes
+        run: |
+          echo "Pushing changes..."
+          git push --set-upstream origin ${{ steps.parse_issue.outputs.branch_name }}
+      - name: Comment on issue with PR link
+        run: |
+          ISSUE_NUMBER=$(echo "${{ github.event.issue.number }}")
+          BRANCH_NAME="note-proposal-${ISSUE_NUMBER}"
+          PR_LINK="https://github.com/${{ github.repository }}/compare/${BRANCH_NAME}?expand=1"
+          COMMENT_BODY="A new branch has been created with your note proposal. You can create a pull request using the following link: ${PR_LINK}"
+          gh api -X POST /repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments -f body="${COMMENT_BODY}"

--- a/ISSUE_TEMPLATE/note-proposal.yml
+++ b/ISSUE_TEMPLATE/note-proposal.yml
@@ -1,0 +1,27 @@
+name: "Note Proposal"
+description: "Propose a new note to be added to the annotations."
+title: "[Note Proposal] "
+labels: ["note-proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the following fields to propose a new note to be added to the annotations.
+  - type: input
+    id: paragraph_number
+    attributes:
+      label: "Paragraph Number"
+      description: "The paragraph number to which the note will be added."
+      placeholder: "Enter the paragraph number"
+  - type: input
+    id: author
+    attributes:
+      label: "Author"
+      description: "The author of the note."
+      placeholder: "Enter the author's name"
+  - type: textarea
+    id: text
+    attributes:
+      label: "Text"
+      description: "The text of the note."
+      placeholder: "Enter the text of the note"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@ This is the source of the website [hpmor.info](https://hpmor.info) which contain
 
 ## Contributing
 
-Contributions of notes are welcome! Please open a pull request with your changes. A convenient way to contribute is to use [the github.dev interface](https://github.dev/DominikPeters/hpmor.info). Paragraphs on hpmor.info have a <kbd>+</kbd> link to their left, which opens a VS Code editor in your browser with the corresponding file open and the paragraph selected. You can then make your changes and open a pull request directly from the editor.
+Contributions of notes are welcome! 
+
+### By proposing a note in an issue
+
+[&rarr; Propose a note](https://github.com/DominikPeters/hpmor-action-test/issues/new?assignees=&labels=note-proposal&projects=&template=note-proposal.yml&title=%5BNote+Proposal%5D+)
+
+If you have a simple note to add, the easiest way is via an "issue".
+Open the issue using the ["Note Proposal" template](https://github.com/DominikPeters/hpmor-action-test/issues/new?assignees=&labels=note-proposal&projects=&template=note-proposal.yml&title=%5BNote+Proposal%5D+).
+Fill in the paragraph number and the text of the note. You can also add your name.
+Once you submit the issue, a bot will add the note to the yaml files and add a comment allowing to open a pull request. You can either open the pull request yourself or wait for me to do it.
+
+### By opening a pull request
+
+If you wish to add several notes, or if you wish to add notes with formatting or based on reddit comments, it is better to directly edit the source files and open a pull request. A convenient way to contribute is to use [the github.dev interface](https://github.dev/DominikPeters/hpmor.info). Paragraphs on hpmor.info have a <kbd>+</kbd> link to their left, which opens a VS Code editor in your browser with the corresponding file open and the paragraph selected. You can then make your changes and open a pull request directly from the editor.
 
 The notes are stored in yaml files in the `yaml` directory. Each chapter has its own file named `<number>.yaml`. The format is as follows:
 

--- a/add-note.py
+++ b/add-note.py
@@ -1,0 +1,42 @@
+import sys
+from ruamel.yaml import YAML
+from datetime import datetime
+
+def parse_issue(issue_body):
+    lines = issue_body.split('\n')
+    paragraph_number = None
+    author = None
+    text = None
+    for line in lines:
+        if line.startswith('### Paragraph Number'):
+            paragraph_number = int(line.split(':')[1].strip())
+        elif line.startswith('### Author'):
+            author = line.split(':')[1].strip()
+        elif line.startswith('### Text'):
+            text = line.split(':', 1)[1].strip()
+    return paragraph_number, author, text
+
+def add_note_to_yaml(paragraph_number, author, text, branch_name, issue_date):
+    yaml = YAML()
+    for i in range(1, 123):
+        with open(f"yaml/{i}.yaml", "r") as f:
+            chapter = yaml.load(f)
+        if paragraph_number in chapter:
+            if 'notes' not in chapter[paragraph_number]:
+                chapter[paragraph_number]['notes'] = []
+            chapter[paragraph_number]['notes'].append({
+                'type': 'original',
+                'date': issue_date,
+                'author': author,
+                'text': text
+            })
+            with open(f"yaml/{i}.yaml", "w") as f:
+                yaml.dump(chapter, f)
+            break
+
+if __name__ == "__main__":
+    issue_body = sys.argv[1]
+    branch_name = sys.argv[2]
+    issue_date = datetime.strptime(sys.argv[3], "%Y-%m-%d").strftime("%Y/%m/%d")
+    paragraph_number, author, text = parse_issue(issue_body)
+    add_note_to_yaml(paragraph_number, author, text, branch_name, issue_date)


### PR DESCRIPTION
Add functionality to allow adding notes via GitHub issues.

* Add `ISSUE_TEMPLATE/note-proposal.yml` with form fields for paragraph number, author field, and text field, and label `note-proposal`.
* Add `.github/workflows/note-proposal.yml` to process issues with the label `note-proposal`, parse the issue, create a new branch, add the note to the relevant yaml file, commit the change, and comment on the issue with a link to create a pull request.
* Add `add-note.py` script to parse the issue, find the correct yaml file, add the note, and save the file using the `ruamel.yaml` library. Include the date when the issue was opened in the yaml output.

